### PR TITLE
perf python scripting: Fix pylint warnings on syscall-counts.py

### DIFF
--- a/tools/perf/scripts/python/syscall-counts.py
+++ b/tools/perf/scripts/python/syscall-counts.py
@@ -11,55 +11,55 @@ import os
 import sys
 
 sys.path.append(os.environ['PERF_EXEC_PATH'] + \
-	'/scripts/python/Perf-Trace-Util/lib/Perf/Trace')
+    '/scripts/python/Perf-Trace-Util/lib/Perf/Trace')
 
 from perf_trace_context import *
 from Core import *
 from Util import syscall_name
 
-usage = "perf script -s syscall-counts.py [comm]\n";
+USAGE = "perf script -s syscall-counts.py [comm]\n"
 
-for_comm = None
+FOR_COMM = None
 
 if len(sys.argv) > 2:
-	sys.exit(usage)
+    sys.exit(USAGE)
 
 if len(sys.argv) > 1:
-	for_comm = sys.argv[1]
+    FOR_COMM = sys.argv[1]
 
 syscalls = autodict()
 
 def trace_begin():
-	print("Press control+C to stop and show the summary")
+    print("Press control+C to stop and show the summary")
 
 def trace_end():
-	print_syscall_totals()
+    print_syscall_totals()
 
 def raw_syscalls__sys_enter(event_name, context, common_cpu,
-		common_secs, common_nsecs, common_pid, common_comm,
-		common_callchain, id, args):
-	if for_comm is not None:
-		if common_comm != for_comm:
-			return
-	try:
-		syscalls[id] += 1
-	except TypeError:
-		syscalls[id] = 1
+        common_secs, common_nsecs, common_pid, common_comm,
+        common_callchain, identity, args):
+    if FOR_COMM is not None:
+        if common_comm != FOR_COMM:
+            return
+    try:
+        syscalls[identity] += 1
+    except TypeError:
+        syscalls[identity] = 1
 
 def syscalls__sys_enter(event_name, context, common_cpu,
-		common_secs, common_nsecs, common_pid, common_comm, id, args):
-	raw_syscalls__sys_enter(**locals())
+        common_secs, common_nsecs, common_pid, common_comm, identity, args):
+    raw_syscalls__sys_enter(**locals())
 
 def print_syscall_totals():
-	if for_comm is not None:
-		print("\nsyscall events for %s:\n" % (for_comm))
-	else:
-		print("\nsyscall events:\n")
+    if FOR_COMM is not None:
+        print("\nsyscall events for %s:\n" % (FOR_COMM))
+    else:
+        print("\nsyscall events:\n")
 
-	print("%-40s  %10s" % ("event", "count"))
-	print("%-40s  %10s" % ("----------------------------------------",
-				"-----------"))
+    print("%-40s  %10s" % ("event", "count"))
+    print("%-40s  %10s" % ("----------------------------------------",
+                "-----------"))
 
-	for id, val in sorted(syscalls.items(),
-			key = lambda kv: (kv[1], kv[0]), reverse = True):
-		print("%-40s  %10d" % (syscall_name(id), val))
+    for identity, val in sorted(syscalls.items(),
+            key = lambda kv: (kv[1], kv[0]), reverse = True):
+        print("%-40s  %10d" % (syscall_name(identity), val))


### PR DESCRIPTION
Fixed warnings such as bad indentation, redefining built-in variables and unnecessary semicolon.